### PR TITLE
Use none from correct MMAL enum

### DIFF
--- a/raspiraw.c
+++ b/raspiraw.c
@@ -1764,7 +1764,7 @@ int main(int argc, char** argv) {
 				break;
 			default:
 				vcos_log_error("Unknown output bit depth %d", cfg.bit_depth);
-				rx_cfg.pack = MMAL_CAMERA_RX_CONFIG_UNPACK_NONE;
+				rx_cfg.pack = MMAL_CAMERA_RX_CONFIG_PACK_NONE;
 				break;
 		}
 	}


### PR DESCRIPTION
From MMAL_CAMERA_RX_CONFIG_PACK instead of
MMAL_CAMERA_RX_CONFIG_UNPACK. Behavior is the same as the
enumerator for NONE is 0 in both.