### PR TITLE
Update Makefile and README.md

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 CROSS_COMPILE ?=
 
-CC	:= $(CROSS_COMPILE)gcc
-CFLAGS ?= -I/opt/vc/include -pipe -W -Wall -Wextra -g -O0 -MD
+CC	?= gcc
+CC	:= $(CROSS_COMPILE)$(CC)
+CFLAGS	?= -I/opt/vc/include -pipe -W -Wall -Wextra -g -O0 -MD
 LDFLAGS	?=
-LIBS	:= -L/opt/vc/lib -lrt -lbcm_host -lvcos -lmmal_core -lmmal_util -lmmal_vc_client -lvcsm
+LIBS	:= -L/opt/vc/lib -lrt -lbcm_host -lvcos -lmmal_core -lmmal_util -lmmal_vc_client -lvcsm -lpthread
 
 %.o : %.c
 	$(CC) $(CFLAGS) -c -o $@ $<
@@ -15,7 +16,7 @@ raspiraw: $(OBJS)
 	$(CC) $(LDFLAGS) -o $@ $^ $(LIBS)
 
 clean:
-	-rm -f *.o
+	-rm -f *.o *.d
 	-rm -f raspiraw
 
 -include $(OBJS:.o=.d)

--- a/README.md
+++ b/README.md
@@ -250,8 +250,8 @@ This is now part of raw2ogg2anim tool.
 #### do once
 
 You have to clone the repo.
-Then "cd raspiraw; ./buildme".
-Finally add this line to your ~/.bashrc.
+Then change directory `cd raspiraw` and build the code by running `make`.  Optionally you can define the compiler with `CC=gcc make` or `CC=clang make`.
+Finally add this line to your `~/.bashrc`.
 
 	$ tail -1 ~/.bashrc 
 	PATH=~/raspiraw:~/raspiraw/tools:$PATH


### PR DESCRIPTION
Clean up readme.  Allow user to pick a compiler other than gcc.
Explicitly link pthread library (for clang).